### PR TITLE
Converts all commands to lower case

### DIFF
--- a/src/builtins/exec_builtins.c
+++ b/src/builtins/exec_builtins.c
@@ -6,11 +6,13 @@
 /*   By: cwenz <cwenz@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/12 16:38:01 by cwenz             #+#    #+#             */
-/*   Updated: 2023/11/28 11:11:12 by cwenz            ###   ########.fr       */
+/*   Updated: 2023/11/30 17:54:15 by cwenz            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+static void	convert_cmd_to_lower(char *cmd);
 
 /// @brief Executes the current builtin.
 /// @param minishell The struct holding all shell data
@@ -48,6 +50,7 @@ bool	is_cmd_builtin(t_minishell *minishell, int i)
 {
 	if (minishell->cmd_table == NULL)
 		return (false);
+	convert_cmd_to_lower(minishell->cmd_table[i]->cmd[0]);
 	if (ft_strcmp(minishell->cmd_table[i]->cmd[0], "cd") == 0)
 		return (true);
 	else if (ft_strcmp(minishell->cmd_table[i]->cmd[0], "pwd") == 0)
@@ -63,4 +66,18 @@ bool	is_cmd_builtin(t_minishell *minishell, int i)
 	else if (ft_strcmp(minishell->cmd_table[i]->cmd[0], "export") == 0)
 		return (true);
 	return (false);
+}
+
+static void	convert_cmd_to_lower(char *cmd)
+{
+	int		i;
+	
+	i = 0;
+	if (!cmd)
+		return ;
+	while (cmd[i])
+	{
+		cmd[i] = ft_tolower(cmd[i]);
+		i++;
+	}
 }

--- a/src/builtins/exec_builtins.c
+++ b/src/builtins/exec_builtins.c
@@ -6,7 +6,7 @@
 /*   By: cwenz <cwenz@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/12 16:38:01 by cwenz             #+#    #+#             */
-/*   Updated: 2023/11/30 17:54:15 by cwenz            ###   ########.fr       */
+/*   Updated: 2023/11/30 18:00:51 by cwenz            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,6 +68,8 @@ bool	is_cmd_builtin(t_minishell *minishell, int i)
 	return (false);
 }
 
+/// @brief Converts the given command to lower case
+/// @param cmd The command to convert
 static void	convert_cmd_to_lower(char *cmd)
 {
 	int		i;

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -6,7 +6,7 @@
 /*   By: cwenz <cwenz@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/15 12:32:52 by cwenz             #+#    #+#             */
-/*   Updated: 2023/11/25 16:05:19 by cwenz            ###   ########.fr       */
+/*   Updated: 2023/11/30 18:02:45 by cwenz            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,13 +15,11 @@
 static void	handle_parent_signal(int signo);
 static void	setup_termios_config(void);
 
-/**
- * @brief  Sets up signal handling for SIGINT (Ctrl-C) and SIGQUIT (Ctrl-\\).
- * 
- *  This function initializes the given signals with the respective signal.
- *  It also sets up the termios settings (terminal config) and how it should
- * 	behave.
- */
+/// @brief  Sets up signal handling for SIGINT (Ctrl-C) and SIGQUIT (Ctrl-\\).
+///
+/// This function initializes the given signals with the respective signal.
+/// It also sets up the termios settings (terminal config) and how it should
+/// behave.
 void	setup_signals(void)
 {
 	struct sigaction	sa_int;


### PR DESCRIPTION
- Fixed bug where builtins with different case would go to `execve`